### PR TITLE
Handle owner with hyphens (or space)

### DIFF
--- a/lib/Anthill.pm
+++ b/lib/Anthill.pm
@@ -51,7 +51,7 @@ DEPLOY
 				deploy  => <<'DEPLOY',
 if SCHEMA_ID('anthill') is null 
 begin
-	exec sp_executesql N'create schema anthill AUTHORIZATION ${owner}';
+	exec sp_executesql N'create schema anthill AUTHORIZATION [${owner}]';
 end	
 go
 if OBJECT_ID('anthill.ant') is null


### PR DESCRIPTION
The schema creation command would fail with "Incorrect syntax near '-'." if called with a user name of "test-user"